### PR TITLE
Use floatarray

### DIFF
--- a/src/graph.ml
+++ b/src/graph.ml
@@ -25,7 +25,7 @@ type node = {
   children: id list;
   sys_time: float;
   allocated_bytes: float;
-  distrib: float array;
+  distrib: floatarray;
 }
 
 type graph = {
@@ -355,10 +355,10 @@ let output ?(threshold = 1.0) oc graph =
   if sample_nodes <> [] then begin
     Printf.fprintf oc "\nSamplings\n----------\n%!";
     let stats d =
-      let avg = (Array.fold_left (+.) 0.0 d) /. (float (Array.length d)) in
+      let avg = (Float.Array.fold_left (+.) 0.0 d) /. (float (Float.Array.length d)) in
       let square x = x *. x in
       let stddev =
-        sqrt ((Array.fold_left (fun acc x -> acc +. square (x -. avg)) 0.0 d) /. (float (Array.length d)))
+        sqrt ((Float.Array.fold_left (fun acc x -> acc +. square (x -. avg)) 0.0 d) /. (float (Float.Array.length d)))
       in
       avg, stddev
     in
@@ -445,7 +445,7 @@ let json_of_node
         "children", List (List.map (fun x -> Int x) children);
         "sys_time", Float sys_time;
         "allocated_bytes", Float allocated_bytes;
-        "distrib", List (List.map (fun x -> Float x) (Array.to_list distrib)) ]
+        "distrib", List (List.map (fun x -> Float x) (Float.Array.to_list distrib)) ]
 
 let json_of_graphs {nodes; label; root} =
   Map ["nodes", ListClosure (Array.length nodes, fun k -> json_of_node nodes.(k));

--- a/src/graph.mli
+++ b/src/graph.mli
@@ -30,7 +30,7 @@ type node = {
   children: id list; (** The list of instances of landmarks that was entered while the node was opened. *)
   sys_time: float; (** Time (using Sys.time) spent between enter and exit. *)
   allocated_bytes: float; (** Gc.allocated_bytes between enter and exit. *)
-  distrib: float array; (** For samplers only. The list of collected samples. *)
+  distrib: floatarray; (** For samplers only. The list of collected samples. *)
 }
 
 (** {3 Callgraph } *)

--- a/tests/random/test.ml
+++ b/tests/random/test.ml
@@ -217,6 +217,6 @@ let checks () =
   end;
   Printf.printf "Check reachability invariant ...\n%!";
   assert (reachable_landmarks graph = reachable_landmarks aggregated_graph);
-  List.iter (fun node -> if node.kind = Sampler then assert(node.calls = Array.length node.distrib)) (nodes graph)
+  List.iter (fun node -> if node.kind = Sampler then assert(node.calls = Float.Array.length node.distrib)) (nodes graph)
 
 let () = checks ()


### PR DESCRIPTION
Switch to use `floatarray` instead of `float array`. Requires a bit of refactoring because the internal module `Landmark.Stack` is polymorphic on `'a array`.