### PR TITLE
Add support for `arm64` (M1 mac)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+unreleased
+------------------------
+* add support for `arm64` (M1 mac) (PR #35, @johnyob)
+
 version 1.4, 15 aug 2021
 ------------------------
 * switch to github actions

--- a/landmarks.opam
+++ b/landmarks.opam
@@ -33,4 +33,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/LexiFi/landmarks.git"
-available: arch = "x86_64" | arch = "x86_32"
+available: arch = "x86_64" | arch = "x86_32" | arch = "arm64"

--- a/landmarks.opam.template
+++ b/landmarks.opam.template
@@ -1,1 +1,1 @@
-available: arch = "x86_64" | arch = "x86_32"
+available: arch = "x86_64" | arch = "x86_32" | arch = "arm64"

--- a/src/clock.c
+++ b/src/clock.c
@@ -15,6 +15,10 @@ CAMLprim value caml_highres_clock(value unit)
     int64_t v;
     v = __rdtsc();
     return caml_copy_int64(v);
+#elif defined(__aarch64__)
+    uint64_t v;
+    __asm__ __volatile__ ("mrs %0, cntvct_el0" : "=r"(v));
+    return caml_copy_int64(v);
 #elif defined(__GNUC__)
     uint32_t hi = 0, lo = 0;
     __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));


### PR DESCRIPTION
**Related Issue**: #33 

Adds support for `arm64`. Tested using an M1 MacBook Pro.