### PR TITLE
ppx-errors test: avoid output variability due to user's .ocamlinit

### DIFF
--- a/tests/ppx-errors/dune
+++ b/tests/ppx-errors/dune
@@ -1,3 +1,8 @@
+; -noinit prevents the toplevel from reading ~/.ocamlinit. Without it, users
+; whose ~/.ocamlinit contains the standard opam-generated "#use \"topfind\""
+; line would see the "Findlib has been successfully loaded..." banner printed
+; to stdout, causing a diff against test.out.expected. The -noinit flag has
+; been available since OCaml 4.02, so it is safe to use unconditionally here.
 (rule
  (targets test.out)
  (deps
@@ -8,7 +13,8 @@
    test.out
    (with-stdin-from
     test.ml
-    (run %{tt} -color never -noprompt -no-version -ppx "%{ppx} --as-ppx")))))
+    (run %{tt} -color never -noprompt -no-version -noinit
+         -ppx "%{ppx} --as-ppx")))))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
I was getting spurious output from `#topfind;;` in this test involving the toplevel, causing a test failure in some environments. The solution is to disable the loading of the user's `.ocamlinit` which is generally a good idea for test reproducibility.

This change is also part of the more complex #47 (https://github.com/LexiFi/landmarks/pull/47/changes#diff-5c5c8d61086236b6ab5bc885c7ff38168f88423d03d55b4257e4c42364488ae2)
