### PR TITLE
Locally open generated landmarks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+----------
+* prevent opened modules from shadowing PPX-generated landmarks
+  (PR #54, @brandonzstride).
+
 version 1.7, 19 jun 2026
 ------------------------
 * stabilize PPX-generated landmark ids across OCaml versions, simplify generated code, and stop auto-instrumenting object methods

--- a/ppx/mapper.ml
+++ b/ppx/mapper.ml
@@ -628,6 +628,9 @@ let toplevel_mapper auto =
                        (register_constant_landmark ~id landmark_name landmark_location))
                     (List.rev !landmarks_to_register))
             in
+            let open_landmarks =
+              Str.open_ (Opn.mk ~loc:first_loc (Mod.structure ~loc:first_loc [landmarks]))
+            in
             match lm with
             | Some lm ->
                 let begin_load =
@@ -640,8 +643,8 @@ let toplevel_mapper auto =
                     [Vb.mk (Pat.construct (mknoloc (Longident.parse "()")) None)
                        (exit_landmark lm)]
                 in
-                landmarks :: (begin_load :: l @ [exit_load])
+                open_landmarks :: (begin_load :: l @ [exit_load])
             | None ->
-                landmarks :: l
+                open_landmarks :: l
         end
   end

--- a/ppx/mapper.ml
+++ b/ppx/mapper.ml
@@ -96,8 +96,14 @@ let rec filter_map f = function
       | Some x -> x :: (filter_map f tl)
       | None -> filter_map f tl
 
+let rec normalize_filename fname =
+  if String.starts_with ~prefix:"./" fname then
+    normalize_filename (String.sub fname 2 (String.length fname - 2))
+  else
+    fname
+
 let string_of_loc (l : Location.t) =
-  let file = l.loc_start.pos_fname in
+  let file = normalize_filename l.loc_start.pos_fname in
   let line = l.loc_start.pos_lnum in
   Printf.sprintf "%s:%d" file line
 
@@ -125,8 +131,9 @@ let register_constant_landmark ?id name location =
 let new_landmark landmark_name loc =
   let landmark = Ppxlib.gen_symbol ~prefix:"__generated_landmark" () in
   let landmark_location = string_of_loc loc in
+  let fname = normalize_filename loc.loc_start.pos_fname in
   landmarks_to_register :=
-    (landmark, landmark_name, landmark_location, Digest.to_hex (Digest.string (loc.loc_start.pos_fname^landmark))) :: !landmarks_to_register;
+    (landmark, landmark_name, landmark_location, Digest.to_hex (Digest.string (fname^landmark))) :: !landmarks_to_register;
   landmark
 
 let qualified ctx name = String.concat "." (List.rev (name :: ctx))

--- a/tests/ppx-auto-open/dune
+++ b/tests/ppx-auto-open/dune
@@ -1,0 +1,36 @@
+(library
+ (name module_a)
+ (modules module_a)
+ (preprocess
+  (pps ppx_landmarks --auto)))
+
+(library
+ (name module_b)
+ (modules module_b)
+ (libraries module_a)
+ (preprocess
+  (pps ppx_landmarks --auto)))
+
+(executable
+ (name test)
+ (modules test)
+ (libraries landmark module_b)
+ (preprocess
+  (pps ppx_landmarks --auto)))
+
+(rule
+ (with-stdout-to
+  test.out
+  (ignore-stderr
+   (setenv
+    "OCAML_LANDMARKS"
+    "on"
+    (run ./test.exe)))))
+
+(rule
+ (alias runtest)
+ (package landmarks-ppx)
+ (enabled_if
+  (>= %{ocaml_version} "4.03"))
+ (action
+  (diff test.out.expected test.out)))

--- a/tests/ppx-auto-open/module_a.ml
+++ b/tests/ppx-auto-open/module_a.ml
@@ -1,0 +1,7 @@
+
+(*
+  This module has landmarks named __generated_landmark__001_ and
+  __generated_landmark__002_
+*)
+
+let dummy a = a

--- a/tests/ppx-auto-open/module_b.ml
+++ b/tests/ppx-auto-open/module_b.ml
@@ -1,0 +1,12 @@
+
+(*
+  This module also has landmarks named __generated_landmark__001_ and
+  __generated_landmark__002_
+
+  The open Module_a should not shadow the landmarks for this module that have
+  the same name.
+*)
+
+open Module_a
+
+let dummy_eta a = dummy a

--- a/tests/ppx-auto-open/test.ml
+++ b/tests/ppx-auto-open/test.ml
@@ -1,0 +1,19 @@
+
+open Module_b
+
+(* Upon exiting each load of Module_a and Module_b, there would be an
+  unrecoverable exception if the landmarks were shadowed. We further check that
+  we reach each landmark. *)
+let () =
+  dummy_eta (print_endline "Hello, world!");
+  if Landmark.profiling () then begin
+    let cg = Landmark.export () in
+    let agg = Landmark.Graph.aggregate_landmarks cg in
+    let all_nodes = Landmark.Graph.nodes agg in
+
+    print_endline "\nLandmark reached:";
+    all_nodes
+    |> List.map (fun { Landmark.Graph.name; _ } -> name)
+    |> List.sort compare
+    |> List.iter print_endline
+  end

--- a/tests/ppx-auto-open/test.out.expected
+++ b/tests/ppx-auto-open/test.out.expected
@@ -1,0 +1,9 @@
+Hello, world!
+
+Landmark reached:
+Module_a.dummy
+Module_b.dummy_eta
+ROOT
+load(module_a)
+load(module_b)
+load(test)

--- a/tests/ppx-file-auto/test.out.expected
+++ b/tests/ppx-file-auto/test.out.expected
@@ -1,21 +1,24 @@
-let __generated_landmark__001_ =
-  Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
-    ~location:"test.ml:1" "Test.f"
-and __generated_landmark__002_ =
-  Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
-    ~location:"test.ml:3" "Test.g"
-and __generated_landmark__003_ =
-  Landmark.register ~id:"cb5f8f2ee6b52fb0dafd8a17b08bf8c9"
-    ~location:"test.ml:9" "Test.f"
-and __generated_landmark__004_ =
-  Landmark.register ~id:"4954ac5ded0c7d5bd4b0b484f5b55e38"
-    ~location:"test.ml:12" "Test._f"
-and __generated_landmark__005_ =
-  Landmark.register ~id:"7cec6cc9c85aa20e37ff5698be1184f6"
-    ~location:"test.ml:13" "Test._f"
-and __generated_landmark__006_ =
-  Landmark.register ~id:"6f6b4e54ce7cd78349ea6da240032099"
-    ~location:"test.ml:1" "load(test)"
+open
+  struct
+    let __generated_landmark__001_ =
+      Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
+        ~location:"test.ml:1" "Test.f"
+    and __generated_landmark__002_ =
+      Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
+        ~location:"test.ml:3" "Test.g"
+    and __generated_landmark__003_ =
+      Landmark.register ~id:"cb5f8f2ee6b52fb0dafd8a17b08bf8c9"
+        ~location:"test.ml:9" "Test.f"
+    and __generated_landmark__004_ =
+      Landmark.register ~id:"4954ac5ded0c7d5bd4b0b484f5b55e38"
+        ~location:"test.ml:12" "Test._f"
+    and __generated_landmark__005_ =
+      Landmark.register ~id:"7cec6cc9c85aa20e37ff5698be1184f6"
+        ~location:"test.ml:13" "Test._f"
+    and __generated_landmark__006_ =
+      Landmark.register ~id:"6f6b4e54ce7cd78349ea6da240032099"
+        ~location:"test.ml:1" "load(test)"
+  end
 let () = Landmark.enter __generated_landmark__006_
 let f x = x + 1
 let f __x0 =

--- a/tests/ppx-file/test.out.expected
+++ b/tests/ppx-file/test.out.expected
@@ -1,9 +1,12 @@
-let __generated_landmark__001_ =
-  Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
-    ~location:"test.ml:1" "Test.named"
-and __generated_landmark__002_ =
-  Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
-    ~location:"test.ml:6" "Test.M.h"
+open
+  struct
+    let __generated_landmark__001_ =
+      Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
+        ~location:"test.ml:1" "Test.named"
+    and __generated_landmark__002_ =
+      Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
+        ~location:"test.ml:6" "Test.M.h"
+  end
 let f x = x + 1
 let f __x0 =
   Landmark.enter __generated_landmark__001_;


### PR DESCRIPTION
Fixes [this](https://github.com/LexiFi/landmarks/pull/53#issuecomment-4924730764) issue in #53.

Landmarks can share names between files (they are `__generated_landmark__001_`,  `__generated_landmark__002_`, etc.), but this means that another file opening that module, if that module does not have an mli and thus exposes its landmarks, will accidently refer that opened module's landmarks, not its own.

This PR encloses landmarks in an `open struct <landmarks here> end` so that they cannot be referenced from outside the defining module.

Tests are not yet updated. I'm awaiting comment, first.