### PR TITLE
Avoid PPX landmark ID collisions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 unreleased
 ----------
 * prevent PPX-generated code with clashing source locations from sharing
-  landmark ids (issue #55).
+  landmark ids (PR #56, @mlasson; reported in issue #55 by @maroneze).
 * prevent opened modules from shadowing PPX-generated landmarks
   (PR #54, @brandonzstride).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 unreleased
 ----------
+* prevent PPX-generated code with clashing source locations from sharing
+  landmark ids (issue #55).
 * prevent opened modules from shadowing PPX-generated landmarks
   (PR #54, @brandonzstride).
 

--- a/ppx/mapper.ml
+++ b/ppx/mapper.ml
@@ -47,7 +47,14 @@ let error loc code =
   Location.Error.raise (Location.Error.make ~loc ~sub:[]
                           (Printf.sprintf "ppx_landmark: %s" (message code)))
 
+module HashString = Hashtbl.Make(struct
+    type t = string
+    let equal = String.equal
+    let hash = Hashtbl.hash
+  end)
+
 let landmarks_to_register = ref []
+let generated_landmark_ids = HashString.create 17
 
 let has_name key {attr_name = {txt; _}; _} = txt = key
 
@@ -128,12 +135,37 @@ let register_landmark ?id name location =
 let register_constant_landmark ?id name location =
   register_landmark ?id (Exp.constant (Const.string name)) location
 
+let reserve_landmark_id key =
+  let rec reserve collision =
+    let key =
+      if collision = 0 then key
+      else Printf.sprintf "%s:%d" key collision
+    in
+    let id = Digest.to_hex (Digest.string key) in
+    if HashString.mem generated_landmark_ids id then
+      reserve (collision + 1)
+    else begin
+      HashString.add generated_landmark_ids id ();
+      id
+    end
+  in
+  reserve 0
+
+let landmark_id loc =
+  let input_name =
+    normalize_filename !Ocaml_common.Location.input_name
+  in
+  let pos = loc.loc_start in
+  let source_name = normalize_filename pos.pos_fname in
+  reserve_landmark_id
+    (Printf.sprintf "%s:%s:%d" input_name source_name pos.pos_cnum)
+
 let new_landmark landmark_name loc =
   let landmark = Ppxlib.gen_symbol ~prefix:"__generated_landmark" () in
   let landmark_location = string_of_loc loc in
-  let fname = normalize_filename loc.loc_start.pos_fname in
   landmarks_to_register :=
-    (landmark, landmark_name, landmark_location, Digest.to_hex (Digest.string (fname^landmark))) :: !landmarks_to_register;
+    (landmark, landmark_name, landmark_location, landmark_id loc)
+    :: !landmarks_to_register;
   landmark
 
 let qualified ctx name = String.concat "." (List.rev (name :: ctx))
@@ -304,12 +336,6 @@ let rec wrap_landmark_method ctx landmark loc ({pexp_desc; _} as expr) =
   | Pexp_poly (e, typ) ->
       { expr with pexp_desc = Pexp_poly (wrap_landmark_method ctx landmark loc e, typ)}
   | _ -> wrap_landmark ctx landmark loc expr
-
-module HashString = Hashtbl.Make(struct
-    type t = string
-    let equal = String.equal
-    let hash = Hashtbl.hash
-  end)
 
 let eta_expand f t n =
   let tbl = HashString.create (List.length n) in

--- a/tests/ppx-file-auto/test.out.expected
+++ b/tests/ppx-file-auto/test.out.expected
@@ -1,22 +1,22 @@
 open
   struct
     let __generated_landmark__001_ =
-      Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
+      Landmark.register ~id:"7b809a6a9a1acad2798b7677e63deba9"
         ~location:"test.ml:1" "Test.f"
     and __generated_landmark__002_ =
-      Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
+      Landmark.register ~id:"8455f741559d9766a547fc29dd14eb1f"
         ~location:"test.ml:3" "Test.g"
     and __generated_landmark__003_ =
-      Landmark.register ~id:"cb5f8f2ee6b52fb0dafd8a17b08bf8c9"
+      Landmark.register ~id:"dbecc4a1266c1809fb2ec3cccab6857d"
         ~location:"test.ml:9" "Test.f"
     and __generated_landmark__004_ =
-      Landmark.register ~id:"4954ac5ded0c7d5bd4b0b484f5b55e38"
+      Landmark.register ~id:"df9eb2ad4ad1cb19806383631430b02a"
         ~location:"test.ml:12" "Test._f"
     and __generated_landmark__005_ =
-      Landmark.register ~id:"7cec6cc9c85aa20e37ff5698be1184f6"
+      Landmark.register ~id:"091dbb5737c78466d0e283f558044fbc"
         ~location:"test.ml:13" "Test._f"
     and __generated_landmark__006_ =
-      Landmark.register ~id:"6f6b4e54ce7cd78349ea6da240032099"
+      Landmark.register ~id:"e797bbb05991be0c495a7046519c6422"
         ~location:"test.ml:1" "load(test)"
   end
 let () = Landmark.enter __generated_landmark__006_

--- a/tests/ppx-file/test.out.expected
+++ b/tests/ppx-file/test.out.expected
@@ -1,10 +1,10 @@
 open
   struct
     let __generated_landmark__001_ =
-      Landmark.register ~id:"ad0280311b486e71f0c77df82f413e7a"
+      Landmark.register ~id:"7b809a6a9a1acad2798b7677e63deba9"
         ~location:"test.ml:1" "Test.named"
     and __generated_landmark__002_ =
-      Landmark.register ~id:"94ce63b73c1f78fc2c48c8219b907a5f"
+      Landmark.register ~id:"fb6f8fe69fd1dd24262ed28be64893a8"
         ~location:"test.ml:6" "Test.M.h"
   end
 let f x = x + 1

--- a/tests/ppx-generated-locations/dune
+++ b/tests/ppx-generated-locations/dune
@@ -1,0 +1,17 @@
+(rule
+ (targets test.out)
+ (deps
+  test.ml
+  (:ppx ../tools/generated_locations_standalone.exe))
+ (action
+  (with-stdout-to
+   test.out
+   (run %{ppx} -impl %{dep:test.ml} -pretty))))
+
+(rule
+ (alias runtest)
+ (package landmarks-ppx)
+ (enabled_if
+  (>= %{ocaml_version} "4.08"))
+ (action
+  (diff test.out.expected test.out)))

--- a/tests/ppx-generated-locations/test.ml
+++ b/tests/ppx-generated-locations/test.ml
@@ -1,0 +1,2 @@
+let[@landmark] first () = ()
+let[@landmark] second () = ()

--- a/tests/ppx-generated-locations/test.out.expected
+++ b/tests/ppx-generated-locations/test.out.expected
@@ -1,0 +1,25 @@
+open
+  struct
+    let __generated_landmark__001_ =
+      Landmark.register ~id:"2deac6ef5f854c99570c35c873f2ecd0"
+        ~location:"_none_:0" "Test.first"
+    and __generated_landmark__002_ =
+      Landmark.register ~id:"2988ee77e77e96393192da67eac16525"
+        ~location:"_none_:0" "Test.second"
+  end
+let first () = ()
+let first __x0 =
+  Landmark.enter __generated_landmark__001_;
+  (let r =
+     try first __x0
+     with | e -> (Landmark.exit __generated_landmark__001_; Landmark.raise e) in
+   Landmark.exit __generated_landmark__001_; r)[@@ocaml.warning "-32-16"]
+  [@@inline ]
+let second () = ()
+let second __x0 =
+  Landmark.enter __generated_landmark__002_;
+  (let r =
+     try second __x0
+     with | e -> (Landmark.exit __generated_landmark__002_; Landmark.raise e) in
+   Landmark.exit __generated_landmark__002_; r)[@@ocaml.warning "-32-16"]
+  [@@inline ]

--- a/tests/tools/dune
+++ b/tests/tools/dune
@@ -1,3 +1,14 @@
 (executable
  (name standalone)
+ (modules standalone)
  (libraries ppxlib ppx_landmarks))
+
+(library
+ (name same_landmark_locations)
+ (modules same_landmark_locations)
+ (libraries ppxlib))
+
+(executable
+ (name generated_locations_standalone)
+ (modules generated_locations_standalone)
+ (libraries ppxlib same_landmark_locations ppx_landmarks))

--- a/tests/tools/generated_locations_standalone.ml
+++ b/tests/tools/generated_locations_standalone.ml
@@ -1,0 +1,3 @@
+let () =
+  ignore Same_landmark_locations.registered;
+  Ppxlib.Driver.standalone ()

--- a/tests/tools/same_landmark_locations.ml
+++ b/tests/tools/same_landmark_locations.ml
@@ -1,0 +1,24 @@
+open Ppxlib
+
+let has_landmark_attribute attributes =
+  List.exists
+    (fun { attr_name = { txt; _ }; _ } -> String.equal txt "landmark")
+    attributes
+
+let erase_landmark_locations =
+  object
+    inherit Ast_traverse.map as super
+
+    method! value_binding value_binding =
+      let value_binding = super # value_binding value_binding in
+      if has_landmark_attribute value_binding.pvb_attributes then
+        { value_binding with pvb_loc = Location.none }
+      else
+        value_binding
+  end
+
+let () =
+  Driver.register_transformation "same-landmark-locations"
+    ~preprocess_impl:(erase_landmark_locations # structure)
+
+let registered = ()


### PR DESCRIPTION
PPX-generated code may reuse or omit source locations, causing distinct landmarks to receive the same ID and alias at runtime.

Generate stable IDs from the compilation unit and source position, with a deterministic counter fallback for collisions. Add a regression test covering landmarks with `Location.none`.

Fixes #55.
